### PR TITLE
chore(requirements): update flask version

### DIFF
--- a/flask_app/requirements.txt
+++ b/flask_app/requirements.txt
@@ -1,2 +1,2 @@
-Flask==2.0.3
+Flask==3.0.3
 gunicorn==20.1.0


### PR DESCRIPTION
**While executing via docker container, getting below error in Werkzeug**
```

app-1  |   File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
app-1  |     return _bootstrap._gcd_import(name[level:], package, level)
app-1  |   File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
app-1  |   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
app-1  |   File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
app-1  |   File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
app-1  |   File "<frozen importlib._bootstrap_external>", line 850, in exec_module
app-1  |   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
app-1  |   File "/app/app.py", line 5, in <module>
app-1  |     from flask import Flask, Response
app-1  |   File "/usr/local/lib/python3.9/site-packages/flask/__init__.py", line 7, in <module>
app-1  |     from .app import Flask as Flask
app-1  |   File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 28, in <module>
app-1  |     from . import cli
app-1  |   File "/usr/local/lib/python3.9/site-packages/flask/cli.py", line 18, in <module>
app-1  |     from .helpers import get_debug_flag
app-1  |   File "/usr/local/lib/python3.9/site-packages/flask/helpers.py", line 16, in <module>
app-1  |     from werkzeug.urls import url_quote
app-1  | ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.9/site-packages/werkzeug/urls.py)
app-1  | [2024-07-25 07:04:32 +0000] [8] [INFO] Worker exiting (pid: 8)
app-1  | [2024-07-25 07:04:32 +0000] [7] [INFO] Shutting down: Master
app-1  | [2024-07-25 07:04:32 +0000] [7] [INFO] Reason: Worker failed to boot.
```


**Reason: **  It is because Werkzeug 3.0.0 was released and Flask doesn't specify the dependency correctly (requirements says Werkzeug>=2.2.0). This is why, Werkzeug 3.0.0 is still installed and Flask 2.2.2 isn't made for Werkzeug 3.0.0.

**Source**: https://stackoverflow.com/questions/77213053/why-did-flask-start-failing-with-importerror-cannot-import-name-url-quote-fr

To resolve the issue, updated the Flask version from **2.0.3 to 3.0.3**, as there were no dependencies on the existing version. Following this update, the application is now running smoothly.


![Uploading Screenshot 2024-07-25 at 11.28.17 AM.png…]()
